### PR TITLE
feature: separate tearDown into stop and tearDown

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,20 +41,17 @@ Here's an example of how you might use NEAR Sandbox in a test with async/await:
 const { Sandbox } = require("near-sandbox");
 
 (async () => {
+  // Start a sandbox instance with default configuration.
+  const sandbox = await Sandbox.start({});
   try {
-    // Start a sandbox instance with default configuration.
-    const sandbox = await Sandbox.start({});
-
     // Your test code here.
     // You can interact with the sandbox via its RPC `sandbox.rpc` etc.
-
     console.log(`Sandbox RPC available at: ${sandbox.rpcUrl}`);
-    // On the end of the working you need stop procces by 'tearDow()' function on sandbox object, there is optional parameter that allow clean up temp dir
-    await sandbox.tearDown();
   } catch (error) {
     console.error("Error during execution:", error);
   } finally {
-    await sandbox.tearDown();
+    // On the end of the working you need stop procces by 'tearDow()' that clear temporary dir or 'stop()' - just stop procces
+    await sandbox.stop();
   }
 })();
 ```
@@ -80,7 +77,7 @@ const { Sandbox } = require("near-sandbox");
 (async () => {
   const sandbox = await Sandbox.start({});
   // Use sandbox.rpc to interact with the local NEAR node.
-  await sandbox.tearDown();
+  await sandbox.stop();
   // stop sandbox after using
 })();
 ```
@@ -94,7 +91,7 @@ const { Sandbox } = require("near-sandbox");
   const sandbox = await Sandbox.start({ version: "2.6.3" });
   // Use `sandbox.rpc` for your further interactions.
   await sandbox.tearDown();
-  // stop sandbox after using
+  // tearDown sandbox after using that clear tmp dir
 })();
 ```
 
@@ -110,7 +107,7 @@ const { Sandbox } = require("near-sandbox");
   };
   const sandbox = await Sandbox.start({ config: config });
 
-  await sandbox.tearDown();
+  await sandbox.stop();
 })();
 ```
 

--- a/__tests__/path.ava.ts
+++ b/__tests__/path.ava.ts
@@ -9,9 +9,18 @@ const TEST_BIN_PATH = join(TEST_BIN_DIR, `near-sandbox-${DEFAULT_NEAR_SANDBOX_VE
 test.before("can use local file", async (t) => {
   process.env['DIR_TO_DOWNLOAD_BINARY'] = TEST_BIN_DIR;
   const sandbox = await Sandbox.start({});
-  const response = await fetch(`${sandbox.rpcUrl}/status`);
-  t.is(response.status, 200);
-  await t.notThrowsAsync(async () => await sandbox.tearDown());
+  try {
+    const response = await fetch(`${sandbox.rpcUrl}/status`);
+    t.is(response.status, 200);
+  } catch (error) {
+    if (error instanceof Error) {
+      t.fail(`${error.message}\n${error.stack}`);
+    } else {
+      t.fail(String(error));
+    }
+  } finally {
+    await t.notThrowsAsync(async () => await sandbox.tearDown());
+  }
 });
 
 test("fails to start sandbox if local binary path does not exist", async (t) => {
@@ -26,7 +35,16 @@ test("fails to start sandbox if local binary path does not exist", async (t) => 
   );
   process.env['NEAR_SANDBOX_BIN_PATH'] = TEST_BIN_PATH;
   const sandbox = await Sandbox.start({});
-  t.truthy(sandbox);
-  await t.notThrowsAsync(async () => await sandbox.tearDown());
-
+  try {
+    const response = await fetch(`${sandbox.rpcUrl}/status`);
+    t.is(response.status, 200);
+  } catch (error) {
+    if (error instanceof Error) {
+      t.fail(`${error.message}\n${error.stack}`);
+    } else {
+      t.fail(String(error));
+    }
+  } finally {
+    await t.notThrowsAsync(async () => await sandbox.tearDown());
+  }
 });

--- a/examples/customConfig.ava.ts
+++ b/examples/customConfig.ava.ts
@@ -25,9 +25,18 @@ test('provide custom config with additional account', async t => {
         ],
     };
     const sandbox = await Sandbox.start({ config });
-    const provider = new JsonRpcProvider({ url: sandbox.rpcUrl });
-    const accountInfo = await provider.viewAccount("alice.near");
+    try {
+        const provider = new JsonRpcProvider({ url: sandbox.rpcUrl });
+        const accountInfo = await provider.viewAccount("alice.near");
 
-    t.is(accountInfo.amount, NEAR.toUnits(1000000));
-    await sandbox.tearDown();
+        t.is(accountInfo.amount, NEAR.toUnits(1000000));
+    } catch (error) {
+        if (error instanceof Error) {
+            t.fail(`${error.message}\n${error.stack}`);
+        } else {
+            t.fail(String(error));
+        }
+    } finally {
+        await sandbox.tearDown();
+    }
 });


### PR DESCRIPTION
feature: previously tearDown(clear?: boolean) accepted an optional flag to decide whether to clear the tmp dir.
Now split into:

stop() – kills the process and releases lock files.

tearDown() – calls stop() and always clears the tmp dir.

This makes the API clearer and avoids overloading tearDown with conditional behavior.